### PR TITLE
Test artifact-submit-action for D1

### DIFF
--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -39,7 +39,7 @@ jobs:
           token: ${{ steps.token.outputs.token }}
       - name: "Submit"
         id: submit
-        uses: acearchive/artifact-submit-action@main
+        uses: acearchive/artifact-submit-action@d1
         with:
           mode: ${{ inputs.mode }}
           path: "submissions/"

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -45,8 +45,10 @@ jobs:
           path: "submissions/"
           base_url: "https://${{ vars.ACE_ARCHIVE_FILES_DOMAIN }}/artifacts"
           base_ref: "main"
-          s3_endpoint: "https://9d143afa60e911e9904e835bd1db8504.r2.cloudflarestorage.com/acearchive-lgbt-artifacts-dev"
-          s3_bucket: "acearchive-lgbt-artifacts-dev"
+          # s3_endpoint: "https://9d143afa60e911e9904e835bd1db8504.r2.cloudflarestorage.com/acearchive-lgbt-artifacts-dev"
+          # s3_bucket: "acearchive-lgbt-artifacts-dev"
+          s3_endpoint: ${{ vars.ARTIFACTS_R2_ENDPOINT }}
+          s3_bucket: ${{ vars.ARTIFACTS_R2_BUCKET }}
           s3_prefix: "artifacts/"
           s3_region: "auto"
           s3_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -54,7 +54,7 @@ jobs:
           s3_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}
           s3_secret_access_key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           submission_worker_secret: ${{ secrets.SUBMISSION_WORKER_DEV_PASSWORD }}
-          submission_worker_domain: "dev.submit.acearchive.lgbt"
+          submission_worker_domain: "submit-dev.acearchive.lgbt"
       - name: "Commit Changes"
         uses: "stefanzweifel/git-auto-commit-action@v4"
         with:

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -45,10 +45,10 @@ jobs:
           path: "submissions/"
           base_url: "https://${{ vars.ACE_ARCHIVE_FILES_DOMAIN }}/artifacts"
           base_ref: "main"
-          # s3_endpoint: "https://9d143afa60e911e9904e835bd1db8504.r2.cloudflarestorage.com/acearchive-lgbt-artifacts-dev"
-          # s3_bucket: "acearchive-lgbt-artifacts-dev"
-          s3_endpoint: ${{ vars.ARTIFACTS_R2_ENDPOINT }}
-          s3_bucket: ${{ vars.ARTIFACTS_R2_BUCKET }}
+          s3_endpoint: "https://9d143afa60e911e9904e835bd1db8504.r2.cloudflarestorage.com"
+          s3_bucket: "acearchive-lgbt-artifacts-dev"
+          # s3_endpoint: ${{ vars.ARTIFACTS_R2_ENDPOINT }}
+          # s3_bucket: ${{ vars.ARTIFACTS_R2_BUCKET }}
           s3_prefix: "artifacts/"
           s3_region: "auto"
           s3_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -50,9 +50,6 @@ jobs:
           s3_region: "auto"
           s3_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}
           s3_secret_access_key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          cloudflare_account_id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          kv_namespace_id: ${{ vars.ARTIFACTS_KV_NAMESPACE_ID }}
       - name: "Commit Changes"
         uses: "stefanzweifel/git-auto-commit-action@v4"
         with:

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -51,6 +51,7 @@ jobs:
           s3_region: "auto"
           s3_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}
           s3_secret_access_key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          submission_worker_secret: ${{ secrets.SUBMISSION_WORKER_PASSWORD }}
       - name: "Commit Changes"
         uses: "stefanzweifel/git-auto-commit-action@v4"
         with:

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v3
         with:
+          # The action needs to be able to tell which files have been modified
+          # in this PR.
+          fetch-depth: 0
           token: ${{ steps.token.outputs.token }}
       - name: "Submit"
         id: submit

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -44,6 +44,7 @@ jobs:
           mode: ${{ inputs.mode }}
           path: "submissions/"
           base_url: "https://${{ vars.ACE_ARCHIVE_FILES_DOMAIN }}/artifacts"
+          base_ref: ${{ github.base_ref }}
           s3_endpoint: ${{ vars.ARTIFACTS_R2_ENDPOINT }}
           s3_bucket: ${{ vars.ARTIFACTS_R2_BUCKET }}
           s3_prefix: "artifacts/"

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -44,7 +44,7 @@ jobs:
           mode: ${{ inputs.mode }}
           path: "submissions/"
           base_url: "https://${{ vars.ACE_ARCHIVE_FILES_DOMAIN }}/artifacts"
-          base_ref: ${{ github.base_ref }}
+          base_ref: "main"
           s3_endpoint: "https://9d143afa60e911e9904e835bd1db8504.r2.cloudflarestorage.com/acearchive-lgbt-artifacts-dev"
           s3_bucket: "acearchive-lgbt-artifacts-dev"
           s3_prefix: "artifacts/"

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -45,14 +45,14 @@ jobs:
           path: "submissions/"
           base_url: "https://${{ vars.ACE_ARCHIVE_FILES_DOMAIN }}/artifacts"
           base_ref: ${{ github.base_ref }}
-          s3_endpoint: ${{ vars.ARTIFACTS_R2_ENDPOINT }}
-          s3_bucket: ${{ vars.ARTIFACTS_R2_BUCKET }}
+          s3_endpoint: "https://9d143afa60e911e9904e835bd1db8504.r2.cloudflarestorage.com/acearchive-lgbt-artifacts-dev"
+          s3_bucket: "acearchive-lgbt-artifacts-dev"
           s3_prefix: "artifacts/"
           s3_region: "auto"
           s3_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}
           s3_secret_access_key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          submission_worker_secret: ${{ secrets.SUBMISSION_WORKER_PASSWORD }}
-          submission_worker_domain: ${{ vars.SUBMISSION_WORKER_DOMAIN }}
+          submission_worker_secret: ${{ secrets.SUBMISSION_WORKER_DEV_PASSWORD }}
+          submission_worker_domain: "dev.submit.acearchive.lgbt"
       - name: "Commit Changes"
         uses: "stefanzweifel/git-auto-commit-action@v4"
         with:

--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -52,6 +52,7 @@ jobs:
           s3_access_key_id: ${{ secrets.R2_ACCESS_KEY_ID }}
           s3_secret_access_key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           submission_worker_secret: ${{ secrets.SUBMISSION_WORKER_PASSWORD }}
+          submission_worker_domain: ${{ vars.SUBMISSION_WORKER_DOMAIN }}
       - name: "Commit Changes"
         uses: "stefanzweifel/git-auto-commit-action@v4"
         with:

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -17,34 +17,34 @@ jobs:
     with:
       mode: "upload"
     secrets: inherit
-  generate:
-    name: "Generate Hugo Files"
-    needs: submit
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Generate Token"
-        id: token
-        # This action is being passed secrets, so we're pinning it to a specific
-        # rev for security. This action is very simple, so it's easy to audit.
-        uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06
-        with:
-          app_id: ${{ vars.GH_APP_ID }}
-          permissions: >-
-            {"contents": "write"}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          repository: "acearchive/hugo-artifacts"
-      - name: "Checkout"
-        uses: actions/checkout@v3
-        with:
-          repository: "acearchive/hugo-artifacts"
-          token: ${{ steps.token.outputs.token }}
-      - name: "Generate Files"
-        uses: "acearchive/hugo-artifact-action@main"
-        with:
-          path: "artifacts/"
-          artifacts: ${{ needs.submit.outputs.artifacts }}
-      - name: "Commit Changes"
-        uses: "stefanzweifel/git-auto-commit-action@v4"
-        with:
-          commit_message: "Apply automatic changes"
-          file_pattern: "artifacts/*.md"
+  # generate:
+  #   name: "Generate Hugo Files"
+  #   needs: submit
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: "Generate Token"
+  #       id: token
+  #       # This action is being passed secrets, so we're pinning it to a specific
+  #       # rev for security. This action is very simple, so it's easy to audit.
+  #       uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06
+  #       with:
+  #         app_id: ${{ vars.GH_APP_ID }}
+  #         permissions: >-
+  #           {"contents": "write"}
+  #         private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+  #         repository: "acearchive/hugo-artifacts"
+  #     - name: "Checkout"
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: "acearchive/hugo-artifacts"
+  #         token: ${{ steps.token.outputs.token }}
+  #     - name: "Generate Files"
+  #       uses: "acearchive/hugo-artifact-action@main"
+  #       with:
+  #         path: "artifacts/"
+  #         artifacts: ${{ needs.submit.outputs.artifacts }}
+  #     - name: "Commit Changes"
+  #       uses: "stefanzweifel/git-auto-commit-action@v4"
+  #       with:
+  #         commit_message: "Apply automatic changes"
+  #         file_pattern: "artifacts/*.md"

--- a/submissions/orlando-the-asexual-manifesto-test.json
+++ b/submissions/orlando-the-asexual-manifesto-test.json
@@ -9,7 +9,9 @@
       "source_url": "https://archive.org/download/asexualmanifestolisaorlando/Asexual-Manifesto-Lisa-Orlando.pdf",
       "lang": "en",
       "hidden": false,
-      "aliases": []
+      "aliases": [],
+      "media_type": "application/pdf",
+      "multihash": "1220f907ed09addad95bd17de1efe76c7a624ba8144f0e2165edaf832447cded5f54"
     },
     {
       "name": "Transcript",
@@ -28,10 +30,17 @@
       "url": "https://archive.org/details/asexualmanifestolisaorlando"
     }
   ],
-  "people": ["Lisa Orlando", "Barbara Getz"],
-  "identities": ["asexual"],
+  "people": [
+    "Lisa Orlando",
+    "Barbara Getz"
+  ],
+  "identities": [
+    "asexual"
+  ],
   "from_year": 1972,
-  "decades": [1970],
+  "decades": [
+    1970
+  ],
   "slug": "orlando-the-asexual-manifesto-test",
   "aliases": [],
   "id": "NXao6CNCreG3"

--- a/submissions/orlando-the-asexual-manifesto-test.json
+++ b/submissions/orlando-the-asexual-manifesto-test.json
@@ -1,0 +1,39 @@
+{
+  "version": 2,
+  "title": "*The Asexual Manifesto*",
+  "summary": "A paper by the Asexual Caucus of the New York Radical Feminists",
+  "files": [
+    {
+      "name": "Digital Scan",
+      "filename": "the-asexual-manifesto.pdf",
+      "source_url": "https://archive.org/download/asexualmanifestolisaorlando/Asexual-Manifesto-Lisa-Orlando.pdf",
+      "lang": "en",
+      "hidden": false,
+      "aliases": [],
+      "media_type": "application/pdf",
+      "multihash": "1220f907ed09addad95bd17de1efe76c7a624ba8144f0e2165edaf832447cded5f54"
+    },
+    {
+      "name": "Transcript",
+      "filename": "the-asexual-manifesto-transcript/index.html",
+      "source_url": "https://w3s.link/ipfs/bafkreihalqtn4l67cdjr5qmzgx2mascbfmws7ohhy3ugmm4nn4jfhzsede",
+      "lang": "en",
+      "hidden": false,
+      "aliases": [],
+      "media_type": "text/html",
+      "multihash": "1220e05c26de2fdf10d31ec19935f4c048412b2d2fb8e7c6e866338d6f1253e64419"
+    }
+  ],
+  "links": [
+    {
+      "name": "Internet Archive",
+      "url": "https://archive.org/details/asexualmanifestolisaorlando"
+    }
+  ],
+  "people": ["Lisa Orlando", "Barbara Getz"],
+  "identities": ["asexual"],
+  "from_year": 1972,
+  "decades": [1970],
+  "slug": "orlando-the-asexual-manifesto-test",
+  "aliases": []
+}

--- a/submissions/orlando-the-asexual-manifesto-test.json
+++ b/submissions/orlando-the-asexual-manifesto-test.json
@@ -9,19 +9,15 @@
       "source_url": "https://archive.org/download/asexualmanifestolisaorlando/Asexual-Manifesto-Lisa-Orlando.pdf",
       "lang": "en",
       "hidden": false,
-      "aliases": [],
-      "media_type": "application/pdf",
-      "multihash": "1220f907ed09addad95bd17de1efe76c7a624ba8144f0e2165edaf832447cded5f54"
+      "aliases": []
     },
     {
       "name": "Transcript",
       "filename": "the-asexual-manifesto-transcript/index.html",
-      "source_url": "https://w3s.link/ipfs/bafkreihalqtn4l67cdjr5qmzgx2mascbfmws7ohhy3ugmm4nn4jfhzsede",
+      "source_url": "https://files.acearchive.lgbt/artifacts/orlando-the-asexual-manifesto/the-asexual-manifesto-transcript/index.html",
       "lang": "en",
       "hidden": false,
-      "aliases": [],
-      "media_type": "text/html",
-      "multihash": "1220e05c26de2fdf10d31ec19935f4c048412b2d2fb8e7c6e866338d6f1253e64419"
+      "aliases": []
     }
   ],
   "links": [
@@ -30,17 +26,10 @@
       "url": "https://archive.org/details/asexualmanifestolisaorlando"
     }
   ],
-  "people": [
-    "Lisa Orlando",
-    "Barbara Getz"
-  ],
-  "identities": [
-    "asexual"
-  ],
+  "people": ["Lisa Orlando", "Barbara Getz"],
+  "identities": ["asexual"],
   "from_year": 1972,
-  "decades": [
-    1970
-  ],
+  "decades": [1970],
   "slug": "orlando-the-asexual-manifesto-test",
   "aliases": [],
   "id": "NXao6CNCreG3"

--- a/submissions/orlando-the-asexual-manifesto-test.json
+++ b/submissions/orlando-the-asexual-manifesto-test.json
@@ -9,9 +9,7 @@
       "source_url": "https://archive.org/download/asexualmanifestolisaorlando/Asexual-Manifesto-Lisa-Orlando.pdf",
       "lang": "en",
       "hidden": false,
-      "aliases": [],
-      "media_type": "application/pdf",
-      "multihash": "1220f907ed09addad95bd17de1efe76c7a624ba8144f0e2165edaf832447cded5f54"
+      "aliases": []
     },
     {
       "name": "Transcript",
@@ -30,17 +28,10 @@
       "url": "https://archive.org/details/asexualmanifestolisaorlando"
     }
   ],
-  "people": [
-    "Lisa Orlando",
-    "Barbara Getz"
-  ],
-  "identities": [
-    "asexual"
-  ],
+  "people": ["Lisa Orlando", "Barbara Getz"],
+  "identities": ["asexual"],
   "from_year": 1972,
-  "decades": [
-    1970
-  ],
+  "decades": [1970],
   "slug": "orlando-the-asexual-manifesto-test",
   "aliases": [],
   "id": "NXao6CNCreG3"

--- a/submissions/orlando-the-asexual-manifesto-test.json
+++ b/submissions/orlando-the-asexual-manifesto-test.json
@@ -30,10 +30,18 @@
       "url": "https://archive.org/details/asexualmanifestolisaorlando"
     }
   ],
-  "people": ["Lisa Orlando", "Barbara Getz"],
-  "identities": ["asexual"],
+  "people": [
+    "Lisa Orlando",
+    "Barbara Getz"
+  ],
+  "identities": [
+    "asexual"
+  ],
   "from_year": 1972,
-  "decades": [1970],
+  "decades": [
+    1970
+  ],
   "slug": "orlando-the-asexual-manifesto-test",
-  "aliases": []
+  "aliases": [],
+  "id": "NXao6CNCreG3"
 }

--- a/submissions/orlando-the-asexual-manifesto-test.json
+++ b/submissions/orlando-the-asexual-manifesto-test.json
@@ -9,7 +9,9 @@
       "source_url": "https://archive.org/download/asexualmanifestolisaorlando/Asexual-Manifesto-Lisa-Orlando.pdf",
       "lang": "en",
       "hidden": false,
-      "aliases": []
+      "aliases": [],
+      "media_type": "application/pdf",
+      "multihash": "1220f907ed09addad95bd17de1efe76c7a624ba8144f0e2165edaf832447cded5f54"
     },
     {
       "name": "Transcript",
@@ -17,7 +19,9 @@
       "source_url": "https://files.acearchive.lgbt/artifacts/orlando-the-asexual-manifesto/the-asexual-manifesto-transcript/index.html",
       "lang": "en",
       "hidden": false,
-      "aliases": []
+      "aliases": [],
+      "media_type": "text/html",
+      "multihash": "1220e05c26de2fdf10d31ec19935f4c048412b2d2fb8e7c6e866338d6f1253e64419"
     }
   ],
   "links": [
@@ -26,10 +30,17 @@
       "url": "https://archive.org/details/asexualmanifestolisaorlando"
     }
   ],
-  "people": ["Lisa Orlando", "Barbara Getz"],
-  "identities": ["asexual"],
+  "people": [
+    "Lisa Orlando",
+    "Barbara Getz"
+  ],
+  "identities": [
+    "asexual"
+  ],
   "from_year": 1972,
-  "decades": [1970],
+  "decades": [
+    1970
+  ],
   "slug": "orlando-the-asexual-manifesto-test",
   "aliases": [],
   "id": "NXao6CNCreG3"


### PR DESCRIPTION
This PR is for testing changes to [artifact-submit-action](https://github.com/acearchive/artifact-submit-action) in preparation for the migration from Workers KV to Workers D1.