### PR TITLE
Hard-code base ref in workflow

### DIFF
--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -44,7 +44,7 @@ jobs:
           mode: ${{ inputs.mode }}
           path: "submissions/"
           base_url: "https://${{ vars.ACE_ARCHIVE_FILES_DOMAIN }}/artifacts"
-          base_ref: ${{ github.base_ref }}
+          base_ref: "main"
           s3_endpoint: ${{ vars.ARTIFACTS_R2_ENDPOINT }}
           s3_bucket: ${{ vars.ARTIFACTS_R2_BUCKET }}
           s3_prefix: "artifacts/"


### PR DESCRIPTION
Apparently, the `${{ github.base_ref }}` value doesn't work for workflows that run after the branch is merged. Let's just hardcode it to `main` for now.