### PR TITLE
Change workflow to upload artifacts on PR review

### DIFF
--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -44,7 +44,7 @@ jobs:
           mode: ${{ inputs.mode }}
           path: "submissions/"
           base_url: "https://${{ vars.ACE_ARCHIVE_FILES_DOMAIN }}/artifacts"
-          base_ref: "main"
+          base_ref: ${{ github.base_ref }}
           s3_endpoint: ${{ vars.ARTIFACTS_R2_ENDPOINT }}
           s3_bucket: ${{ vars.ARTIFACTS_R2_BUCKET }}
           s3_prefix: "artifacts/"

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -1,17 +1,16 @@
 name: "Upload Submissions"
 
-# Because Workers KV is an eventually consistent system, we need to ensure that
-# only one process is ever writing to the KV namespace at a time.
 concurrency: "upload"
 
 on:
   workflow_dispatch:
-  push:
-    paths: ["submissions/*.json"]
-    branches: ["main"]
+  pull_request_review:
+    types: ["submitted"]
 
 jobs:
   submit:
+    # Only run on approving PR reviews.
+    if: github.event.review.state == 'APPROVED'
     name: "Submit Artifacts"
     uses: ./.github/workflows/submit.yaml
     with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ start with `[Edit]`.
 To add a submission to the archive, you need to check it into this repo as a
 JSON file under the [`submissions/`](./submissions/) directory. At this point,
 you can make any changes you deem necessary to the user's submission by hand.
-The name of the JSON file should be the artifact slug. You should open a PR with
-the change; do not commit directly to `main`.
+The name of the JSON file should be the artifact slug. You must open a PR with
+the change; committing directly to `main` is disallowed by the repo settings.
 
 The PR title should start with `[Submission]` or `[Edit]`. Link to the issue
 number in the PR body.
@@ -37,13 +37,11 @@ fields, it's important that you follow each of the URLs of files in the
 submission to make sure they point where you expect them to. The idea is to make
 sure the links are direct download links and not web pages, the files haven't
 been deleted since the user created the submission, the files aren't malicious,
-etc. When you merge the PR, a second CI job will compare the hash again before
+etc. When you approve the PR, a second CI job will compare the hash again before
 uploading it to Ace Archive to make sure the file hasn't changed out from under
-you since you manually reviewed it. You want to do this review after the
-validation job (which calculates the hash) runs but before you merge the PR so
-that you can be sure the file doesn't change out from under you.
+you since you reviewed it.
 
-Once your PR in this repo is merged, the artifact will be returned by the Ace
+Once your PR in this repo is approved, the artifact will be returned by the Ace
 Archive API, but will not yet appear on the website. To make the artifact appear
 on the site, you need to check out the
 [acearchive/acearchive.lgbt](https://github.com/acearchive/acearchive.lgbt) repo

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ team members can manually edit the JSON if necessary without the bot overwriting
 their changes. Likewise, team members can delete the file hash or media type
 fields to have the bot recalculate them.
 
-When a PR is merged, the action downloads the files, re-hashes them to verify
-that the contents at the URL haven't changed since the PR was approved, and then
-uploads them to Ace Archive.
+When a PR is approved, the action downloads the files, re-hashes them to verify
+that the contents at the URL haven't changed, and then uploads them to Ace
+Archive.
 
 Additionally,
 [acearchive/hugo-artifact-action](https://github.com/acearchive/hugo-artifact-action)


### PR DESCRIPTION
Because [artifact-submit-action](https://github.com/acearchive/artifact-submit-action) decides which artifacts to upload to the site by diffing the current branch against the base branch, we can no longer run the workflow when the PR is merged, because then it's diffing `main` against `main`.

Instead, we're changing the workflow to upload artifacts when the PR is approved. I've also edited the repo settings to require approvals on PRs. I think this workflow makes more sense anyways.