### PR TITLE
Fix behavior when deciding which artifacts to upload

### DIFF
--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -44,7 +44,7 @@ jobs:
           mode: ${{ inputs.mode }}
           path: "submissions/"
           base_url: "https://${{ vars.ACE_ARCHIVE_FILES_DOMAIN }}/artifacts"
-          base_ref: "main"
+          base_ref: "HEAD~1"
           s3_endpoint: ${{ vars.ARTIFACTS_R2_ENDPOINT }}
           s3_bucket: ${{ vars.ARTIFACTS_R2_BUCKET }}
           s3_prefix: "artifacts/"

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -1,7 +1,5 @@
 name: "Upload Submissions"
 
-# Because Workers KV is an eventually consistent system, we need to ensure that
-# only one process is ever writing to the KV namespace at a time.
 concurrency: "upload"
 
 on:


### PR DESCRIPTION
Because [artifact-submit-action](https://github.com/acearchive/artifact-submit-action) decides which artifacts to upload to the site by diffing the current branch against the base branch, we can no longer run the workflow when the PR is merged, because then it's diffing `main` against `main`.

To solve this, we're using `HEAD~1` as the base ref to diff against.