### PR TITLE
Parameterize base_ref for workflow_dispatch

### DIFF
--- a/.github/workflows/submit.yaml
+++ b/.github/workflows/submit.yaml
@@ -6,6 +6,15 @@ on:
       mode:
         required: true
         type: string
+      # artifact-submit-action uses git to determine which artifacts have
+      # changed and need to be validated/uploaded. We parameterize this here so
+      # that we can accept it as a workflow_dispatch input in the other
+      # workflows. That way, if we ever need to manually kick off one of those
+      # workflows, we can specify the base branch and therefore exactly which
+      # artifacts need to be validated/uploaded.
+      base_ref:
+        required: true
+        type: string
     outputs:
       artifacts:
         description: >
@@ -44,7 +53,7 @@ jobs:
           mode: ${{ inputs.mode }}
           path: "submissions/"
           base_url: "https://${{ vars.ACE_ARCHIVE_FILES_DOMAIN }}/artifacts"
-          base_ref: "HEAD~1"
+          base_ref: ${{ inputs.base_ref }}
           s3_endpoint: ${{ vars.ARTIFACTS_R2_ENDPOINT }}
           s3_bucket: ${{ vars.ARTIFACTS_R2_BUCKET }}
           s3_prefix: "artifacts/"

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -4,6 +4,12 @@ concurrency: "upload"
 
 on:
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "The base ref to determine which artifacts to upload"
+        required: true
+        default: "HEAD~1"
+        type: string
   push:
     paths: ["submissions/*.json"]
     branches: ["main"]
@@ -14,6 +20,8 @@ jobs:
     uses: ./.github/workflows/submit.yaml
     with:
       mode: "upload"
+      # We default to HEAD~1 for push events.
+      base_ref: ${{ github.event.inputs.base_ref || "HEAD~1" }}
     secrets: inherit
   generate:
     name: "Generate Hugo Files"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,6 +2,12 @@ name: "Validate Submissions"
 
 on:
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "The base ref to determine which artifacts to upload"
+        required: true
+        default: "HEAD~1"
+        type: string
   pull_request:
     paths: ["submissions/*.json"]
 
@@ -11,4 +17,6 @@ jobs:
     uses: ./.github/workflows/submit.yaml
     with:
       mode: "validate"
+      # We default to HEAD~1 for pull_request events.
+      base_ref: ${{ github.event.inputs.base_ref || "HEAD~1" }}
     secrets: inherit


### PR DESCRIPTION
From a comment in this PR:

> artifact-submit-action uses git to determine which artifacts have changed and need to be validated/uploaded. We parameterize this here so that we can accept it as a workflow_dispatch input in the other workflows. That way, if we ever need to manually kick off one of those workflows, we can specify the base branch and therefore exactly which artifacts need to be validated/uploaded.