### PR TITLE
Remove Wayback URLs in line with new guidance

### DIFF
--- a/submissions/aven-forums-avenguy-semisexuality.json
+++ b/submissions/aven-forums-avenguy-semisexuality.json
@@ -11,9 +11,15 @@
       "url": "https://www.asexuality.org/en/topic/1629-semisexuality/"
     }
   ],
-  "people": ["David Jay"],
-  "identities": ["asexual"],
-  "decades": [2000],
+  "people": [
+    "David Jay"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    2000
+  ],
   "aliases": [],
   "id": "TJOxYmz9d2ke",
   "from_year": 2003

--- a/submissions/aven-forums-avenguy-semisexuality.json
+++ b/submissions/aven-forums-avenguy-semisexuality.json
@@ -9,21 +9,11 @@
     {
       "name": "Forum Thread",
       "url": "https://www.asexuality.org/en/topic/1629-semisexuality/"
-    },
-    {
-      "name": "Forum Thread",
-      "url": "https://web.archive.org/web/20220127050626/https://www.asexuality.org/en/topic/1629-semisexuality/"
     }
   ],
-  "people": [
-    "David Jay"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    2000
-  ],
+  "people": ["David Jay"],
+  "identities": ["asexual"],
+  "decades": [2000],
   "aliases": [],
   "id": "TJOxYmz9d2ke",
   "from_year": 2003

--- a/submissions/aven-forums-black-rings-asexual-pride.json
+++ b/submissions/aven-forums-black-rings-asexual-pride.json
@@ -8,19 +8,11 @@
     {
       "name": "Forum Thread",
       "url": "https://www.asexuality.org/en/topic/76607-black-rings-and-other-ways-to-show-asexual-pride/"
-    },
-    {
-      "name": "Forum Thread",
-      "url": "https://web.archive.org/web/20220120151311/https://www.asexuality.org/en/topic/76607-black-rings-and-other-ways-to-show-asexual-pride/"
     }
   ],
   "people": [],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    2000
-  ],
+  "identities": ["asexual"],
+  "decades": [2000],
   "aliases": [],
   "id": "IwaR0PUb2al7",
   "from_year": 2005

--- a/submissions/aven-forums-black-rings-asexual-pride.json
+++ b/submissions/aven-forums-black-rings-asexual-pride.json
@@ -11,8 +11,12 @@
     }
   ],
   "people": [],
-  "identities": ["asexual"],
-  "decades": [2000],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    2000
+  ],
   "aliases": [],
   "id": "IwaR0PUb2al7",
   "from_year": 2005

--- a/submissions/aven-forums-hexaquark-a-history-of-asexuality.json
+++ b/submissions/aven-forums-hexaquark-a-history-of-asexuality.json
@@ -8,21 +8,11 @@
     {
       "name": "Forum Thread",
       "url": "https://www.asexuality.org/en/topic/62278-a-history-of-asexuality"
-    },
-    {
-      "name": "Forum Thread",
-      "url": "https://web.archive.org/web/20210716012607/https://www.asexuality.org/en/topic/62278-a-history-of-asexuality/"
     }
   ],
-  "people": [
-    "hexaquark"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    2010
-  ],
+  "people": ["hexaquark"],
+  "identities": ["asexual"],
+  "decades": [2010],
   "aliases": [],
   "id": "uiK0Mgomz3yF",
   "from_year": 2011

--- a/submissions/aven-forums-hexaquark-a-history-of-asexuality.json
+++ b/submissions/aven-forums-hexaquark-a-history-of-asexuality.json
@@ -10,9 +10,15 @@
       "url": "https://www.asexuality.org/en/topic/62278-a-history-of-asexuality"
     }
   ],
-  "people": ["hexaquark"],
-  "identities": ["asexual"],
-  "decades": [2010],
+  "people": [
+    "hexaquark"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    2010
+  ],
   "aliases": [],
   "id": "uiK0Mgomz3yF",
   "from_year": 2011

--- a/submissions/aven-forums-kspaz-gray-a.json
+++ b/submissions/aven-forums-kspaz-gray-a.json
@@ -8,22 +8,11 @@
     {
       "name": "Forum Thread",
       "url": "https://www.asexuality.org/en/topic/15539-gray-as/"
-    },
-    {
-      "name": "Forum Thread",
-      "url": "https://web.archive.org/web/20220328213011/https://www.asexuality.org/en/topic/15539-gray-as/"
     }
   ],
-  "people": [
-    "KSpaz"
-  ],
-  "identities": [
-    "asexual",
-    "gray-asexual"
-  ],
-  "decades": [
-    2000
-  ],
+  "people": ["KSpaz"],
+  "identities": ["asexual", "gray-asexual"],
+  "decades": [2000],
   "aliases": [],
   "id": "S4BHsMdFia0w",
   "from_year": 2006

--- a/submissions/aven-forums-kspaz-gray-a.json
+++ b/submissions/aven-forums-kspaz-gray-a.json
@@ -10,9 +10,16 @@
       "url": "https://www.asexuality.org/en/topic/15539-gray-as/"
     }
   ],
-  "people": ["KSpaz"],
-  "identities": ["asexual", "gray-asexual"],
-  "decades": [2000],
+  "people": [
+    "KSpaz"
+  ],
+  "identities": [
+    "asexual",
+    "gray-asexual"
+  ],
+  "decades": [
+    2000
+  ],
   "aliases": [],
   "id": "S4BHsMdFia0w",
   "from_year": 2006

--- a/submissions/aven-forums-raisin-squish.json
+++ b/submissions/aven-forums-raisin-squish.json
@@ -10,9 +10,15 @@
       "url": "https://www.asexuality.org/en/topic/23290-squish/"
     }
   ],
-  "people": ["Raisin"],
-  "identities": ["aromantic"],
-  "decades": [2000],
+  "people": [
+    "Raisin"
+  ],
+  "identities": [
+    "aromantic"
+  ],
+  "decades": [
+    2000
+  ],
   "aliases": [],
   "id": "eBL4HFzTVIfx",
   "from_year": 2007

--- a/submissions/aven-forums-raisin-squish.json
+++ b/submissions/aven-forums-raisin-squish.json
@@ -8,21 +8,11 @@
     {
       "name": "Forum Thread",
       "url": "https://www.asexuality.org/en/topic/23290-squish/"
-    },
-    {
-      "name": "Forum Thread",
-      "url": "https://web.archive.org/web/20220120192010/https://www.asexuality.org/en/topic/23290-squish/"
     }
   ],
-  "people": [
-    "Raisin"
-  ],
-  "identities": [
-    "aromantic"
-  ],
-  "decades": [
-    2000
-  ],
+  "people": ["Raisin"],
+  "identities": ["aromantic"],
+  "decades": [2000],
   "aliases": [],
   "id": "eBL4HFzTVIfx",
   "from_year": 2007

--- a/submissions/aven-forums-sonofzeal-asexual-sex.json
+++ b/submissions/aven-forums-sonofzeal-asexual-sex.json
@@ -10,9 +10,16 @@
       "url": "https://www.asexuality.org/en/topic/14000-asexual-sex/"
     }
   ],
-  "people": ["sonofzeal"],
-  "identities": ["asexual", "demisexual"],
-  "decades": [2000],
+  "people": [
+    "sonofzeal"
+  ],
+  "identities": [
+    "asexual",
+    "demisexual"
+  ],
+  "decades": [
+    2000
+  ],
   "aliases": [],
   "id": "hyURgyzMNTsV",
   "from_year": 2006

--- a/submissions/aven-forums-sonofzeal-asexual-sex.json
+++ b/submissions/aven-forums-sonofzeal-asexual-sex.json
@@ -8,22 +8,11 @@
     {
       "name": "Forum Thread",
       "url": "https://www.asexuality.org/en/topic/14000-asexual-sex/"
-    },
-    {
-      "name": "Forum Thread",
-      "url": "https://web.archive.org/web/20220328213010/https://www.asexuality.org/en/topic/14000-asexual-sex/"
     }
   ],
-  "people": [
-    "sonofzeal"
-  ],
-  "identities": [
-    "asexual",
-    "demisexual"
-  ],
-  "decades": [
-    2000
-  ],
+  "people": ["sonofzeal"],
+  "identities": ["asexual", "demisexual"],
+  "decades": [2000],
   "aliases": [],
   "id": "hyURgyzMNTsV",
   "from_year": 2006

--- a/submissions/bogaert-asexuality-prevalence.json
+++ b/submissions/bogaert-asexuality-prevalence.json
@@ -31,9 +31,15 @@
       "url": "https://doi.org/10.1080/00224490409552235"
     }
   ],
-  "people": ["Anthony Bogaert"],
-  "identities": ["asexual"],
-  "decades": [2000],
+  "people": [
+    "Anthony Bogaert"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    2000
+  ],
   "aliases": [],
   "id": "rbArjAmvNnIi",
   "from_year": 2004

--- a/submissions/bogaert-asexuality-prevalence.json
+++ b/submissions/bogaert-asexuality-prevalence.json
@@ -29,21 +29,11 @@
     {
       "name": "Journal Page",
       "url": "https://doi.org/10.1080/00224490409552235"
-    },
-    {
-      "name": "Journal Page",
-      "url": "https://web.archive.org/web/20220430153700/https://www.tandfonline.com/doi/abs/10.1080/00224490409552235"
     }
   ],
-  "people": [
-    "Anthony Bogaert"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    2000
-  ],
+  "people": ["Anthony Bogaert"],
+  "identities": ["asexual"],
+  "decades": [2000],
   "aliases": [],
   "id": "rbArjAmvNnIi",
   "from_year": 2004

--- a/submissions/cnn-one-in-100-adults-asexual.json
+++ b/submissions/cnn-one-in-100-adults-asexual.json
@@ -9,21 +9,11 @@
     {
       "name": "Article",
       "url": "https://www.cnn.com/2004/TECH/science/10/14/asexual.study/index.html"
-    },
-    {
-      "name": "Article",
-      "url": "https://web.archive.org/web/20220401030329/http://www.cnn.com/2004/TECH/science/10/14/asexual.study/index.html"
     }
   ],
-  "people": [
-    "Anthony Bogaert"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    2000
-  ],
+  "people": ["Anthony Bogaert"],
+  "identities": ["asexual"],
+  "decades": [2000],
   "aliases": [],
   "id": "7JQmFs7h1U5y",
   "from_year": 2004

--- a/submissions/cnn-one-in-100-adults-asexual.json
+++ b/submissions/cnn-one-in-100-adults-asexual.json
@@ -11,9 +11,15 @@
       "url": "https://www.cnn.com/2004/TECH/science/10/14/asexual.study/index.html"
     }
   ],
-  "people": ["Anthony Bogaert"],
-  "identities": ["asexual"],
-  "decades": [2000],
+  "people": [
+    "Anthony Bogaert"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    2000
+  ],
   "aliases": [],
   "id": "7JQmFs7h1U5y",
   "from_year": 2004

--- a/submissions/copetas-burroughs-interviews-bowie.json
+++ b/submissions/copetas-burroughs-interviews-bowie.json
@@ -8,21 +8,11 @@
     {
       "name": "Article",
       "url": "https://www.rollingstone.com/feature/beat-godfather-meets-glitter-mainman-william-burroughs-interviews-david-bowie-92508/"
-    },
-    {
-      "name": "Article",
-      "url": "https://web.archive.org/web/20220208013142/https://www.rollingstone.com/feature/beat-godfather-meets-glitter-mainman-william-burroughs-interviews-david-bowie-92508/"
     }
   ],
-  "people": [
-    "David Bowie"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    1970
-  ],
+  "people": ["David Bowie"],
+  "identities": ["asexual"],
+  "decades": [1970],
   "aliases": [],
   "id": "jHQ0bvOaYllU",
   "from_year": 1974

--- a/submissions/copetas-burroughs-interviews-bowie.json
+++ b/submissions/copetas-burroughs-interviews-bowie.json
@@ -10,9 +10,15 @@
       "url": "https://www.rollingstone.com/feature/beat-godfather-meets-glitter-mainman-william-burroughs-interviews-david-bowie-92508/"
     }
   ],
-  "people": ["David Bowie"],
-  "identities": ["asexual"],
-  "decades": [1970],
+  "people": [
+    "David Bowie"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    1970
+  ],
   "aliases": [],
   "id": "jHQ0bvOaYllU",
   "from_year": 1974

--- a/submissions/cor-a-thought-wtfromantic.json
+++ b/submissions/cor-a-thought-wtfromantic.json
@@ -8,22 +8,11 @@
     {
       "name": "Blog Post",
       "url": "https://epochryphal.tumblr.com/post/37572886173/a-thought-wtfromantic-is-a-very-important"
-    },
-    {
-      "name": "Blog Post",
-      "url": "https://web.archive.org/web/20220328212347/https://epochryphal.tumblr.com/post/37572886173/a-thought-wtfromantic-is-a-very-important"
     }
   ],
-  "people": [
-    "Cor"
-  ],
-  "identities": [
-    "wtfromantic",
-    "quoiromantic"
-  ],
-  "decades": [
-    2010
-  ],
+  "people": ["Cor"],
+  "identities": ["wtfromantic", "quoiromantic"],
+  "decades": [2010],
   "aliases": [],
   "id": "nClmNtUMYrqH",
   "from_year": 2012

--- a/submissions/cor-a-thought-wtfromantic.json
+++ b/submissions/cor-a-thought-wtfromantic.json
@@ -10,9 +10,16 @@
       "url": "https://epochryphal.tumblr.com/post/37572886173/a-thought-wtfromantic-is-a-very-important"
     }
   ],
-  "people": ["Cor"],
-  "identities": ["wtfromantic", "quoiromantic"],
-  "decades": [2010],
+  "people": [
+    "Cor"
+  ],
+  "identities": [
+    "wtfromantic",
+    "quoiromantic"
+  ],
+  "decades": [
+    2010
+  ],
   "aliases": [],
   "id": "nClmNtUMYrqH",
   "from_year": 2012

--- a/submissions/coyote-aro-throwback-hour.json
+++ b/submissions/coyote-aro-throwback-hour.json
@@ -10,9 +10,15 @@
       "url": "https://www.pillowfort.social/posts/2580244"
     }
   ],
-  "people": ["Coyote"],
-  "identities": ["aromantic"],
-  "decades": [2010],
+  "people": [
+    "Coyote"
+  ],
+  "identities": [
+    "aromantic"
+  ],
+  "decades": [
+    2010
+  ],
   "aliases": [],
   "id": "fDqRu5Im2H22",
   "from_year": 2010,

--- a/submissions/coyote-aro-throwback-hour.json
+++ b/submissions/coyote-aro-throwback-hour.json
@@ -8,21 +8,11 @@
     {
       "name": "Pillowfort",
       "url": "https://www.pillowfort.social/posts/2580244"
-    },
-    {
-      "name": "Pillowfort",
-      "url": "https://web.archive.org/web/20230924154110/https://www.pillowfort.social/posts/2580244"
     }
   ],
-  "people": [
-    "Coyote"
-  ],
-  "identities": [
-    "aromantic"
-  ],
-  "decades": [
-    2010
-  ],
+  "people": ["Coyote"],
+  "identities": ["aromantic"],
+  "decades": [2010],
   "aliases": [],
   "id": "fDqRu5Im2H22",
   "from_year": 2010,

--- a/submissions/coyote-genealogy-of-queerplatonic.json
+++ b/submissions/coyote-genealogy-of-queerplatonic.json
@@ -10,28 +10,13 @@
       "url": "https://theacetheist.wordpress.com/2019/03/09/a-genealogy-of-queerplatonic/"
     },
     {
-      "name": "Part 1",
-      "url": "https://web.archive.org/web/20230709033032/https://theacetheist.wordpress.com/2019/03/09/a-genealogy-of-queerplatonic/"
-    },
-    {
       "name": "Part 2",
       "url": "https://theacetheist.wordpress.com/2019/03/11/bonus-round-queerplatonic-adjacent-concepts/"
-    },
-    {
-      "name": "Part 2",
-      "url": "https://web.archive.org/web/20230315101847/https://theacetheist.wordpress.com/2019/03/11/bonus-round-queerplatonic-adjacent-concepts/"
     }
   ],
-  "people": [
-    "Coyote"
-  ],
-  "identities": [
-    "aromantic",
-    "queerplatonic"
-  ],
-  "decades": [
-    2010
-  ],
+  "people": ["Coyote"],
+  "identities": ["aromantic", "queerplatonic"],
+  "decades": [2010],
   "aliases": [],
   "id": "w1Ie5VuRrbg8",
   "from_year": 2019

--- a/submissions/coyote-genealogy-of-queerplatonic.json
+++ b/submissions/coyote-genealogy-of-queerplatonic.json
@@ -14,9 +14,16 @@
       "url": "https://theacetheist.wordpress.com/2019/03/11/bonus-round-queerplatonic-adjacent-concepts/"
     }
   ],
-  "people": ["Coyote"],
-  "identities": ["aromantic", "queerplatonic"],
-  "decades": [2010],
+  "people": [
+    "Coyote"
+  ],
+  "identities": [
+    "aromantic",
+    "queerplatonic"
+  ],
+  "decades": [
+    2010
+  ],
   "aliases": [],
   "id": "w1Ie5VuRrbg8",
   "from_year": 2019

--- a/submissions/duenwald-saying-no-is-easy.json
+++ b/submissions/duenwald-saying-no-is-easy.json
@@ -9,21 +9,11 @@
     {
       "name": "Article",
       "url": "https://www.nytimes.com/2005/06/09/fashion/thursdaystyles/for-them-just-saying-no-is-easy.html"
-    },
-    {
-      "name": "Article",
-      "url": "https://web.archive.org/web/20220422192722/https://www.nytimes.com/2005/06/09/fashion/thursdaystyles/for-them-just-saying-no-is-easy.html"
     }
   ],
-  "people": [
-    "Mary Duenwald"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    2000
-  ],
+  "people": ["Mary Duenwald"],
+  "identities": ["asexual"],
+  "decades": [2000],
   "aliases": [],
   "id": "VeJMSkMqCk3J",
   "from_year": 2005

--- a/submissions/duenwald-saying-no-is-easy.json
+++ b/submissions/duenwald-saying-no-is-easy.json
@@ -11,9 +11,15 @@
       "url": "https://www.nytimes.com/2005/06/09/fashion/thursdaystyles/for-them-just-saying-no-is-easy.html"
     }
   ],
-  "people": ["Mary Duenwald"],
-  "identities": ["asexual"],
-  "decades": [2000],
+  "people": [
+    "Mary Duenwald"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    2000
+  ],
   "aliases": [],
   "id": "VeJMSkMqCk3J",
   "from_year": 2005

--- a/submissions/hernandez-asexual-protagonists.json
+++ b/submissions/hernandez-asexual-protagonists.json
@@ -21,9 +21,16 @@
       "url": "https://digitalcommons.augustana.edu/wollstonecraftaward/41/"
     }
   ],
-  "people": ["Jaclyn Hernandez"],
-  "identities": ["asexual", "aromantic"],
-  "decades": [2020],
+  "people": [
+    "Jaclyn Hernandez"
+  ],
+  "identities": [
+    "asexual",
+    "aromantic"
+  ],
+  "decades": [
+    2020
+  ],
   "aliases": [],
   "id": "spcX90OYN8vV",
   "from_year": 2021

--- a/submissions/hernandez-asexual-protagonists.json
+++ b/submissions/hernandez-asexual-protagonists.json
@@ -19,22 +19,11 @@
     {
       "name": "Augustana Digital Commons",
       "url": "https://digitalcommons.augustana.edu/wollstonecraftaward/41/"
-    },
-    {
-      "name": "Augustana Digital Commons",
-      "url": "https://web.archive.org/web/20230514215202/https://digitalcommons.augustana.edu/wollstonecraftaward/41/"
     }
   ],
-  "people": [
-    "Jaclyn Hernandez"
-  ],
-  "identities": [
-    "asexual",
-    "aromantic"
-  ],
-  "decades": [
-    2020
-  ],
+  "people": ["Jaclyn Hernandez"],
+  "identities": ["asexual", "aromantic"],
+  "decades": [2020],
   "aliases": [],
   "id": "spcX90OYN8vV",
   "from_year": 2021

--- a/submissions/hirschfeld-sappho-und-sokrates.json
+++ b/submissions/hirschfeld-sappho-und-sokrates.json
@@ -35,9 +35,15 @@
       "url": "https://www.asexuality.org/en/topic/98639-indirect-mentions-of-asexuality-in-magnus-hirschfelds-books/"
     }
   ],
-  "people": ["Magnus Hirschfeld"],
-  "identities": ["asexual"],
-  "decades": [1890],
+  "people": [
+    "Magnus Hirschfeld"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    1890
+  ],
   "aliases": [],
   "id": "KVTv9LGw4ToR",
   "from_year": 1896

--- a/submissions/hirschfeld-sappho-und-sokrates.json
+++ b/submissions/hirschfeld-sappho-und-sokrates.json
@@ -33,21 +33,11 @@
     {
       "name": "Partial English Translation",
       "url": "https://www.asexuality.org/en/topic/98639-indirect-mentions-of-asexuality-in-magnus-hirschfelds-books/"
-    },
-    {
-      "name": "Partial English Translation",
-      "url": "https://web.archive.org/web/20220120124921/https://www.asexuality.org/en/topic/98639-indirect-mentions-of-asexuality-in-magnus-hirschfelds-books/"
     }
   ],
-  "people": [
-    "Magnus Hirschfeld"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    1890
-  ],
+  "people": ["Magnus Hirschfeld"],
+  "identities": ["asexual"],
+  "decades": [1890],
   "aliases": [],
   "id": "KVTv9LGw4ToR",
   "from_year": 1896

--- a/submissions/hirschfeld-sexualpathologie.json
+++ b/submissions/hirschfeld-sexualpathologie.json
@@ -45,9 +45,15 @@
       "url": "https://www.asexuality.org/en/topic/98639-indirect-mentions-of-asexuality-in-magnus-hirschfelds-books/"
     }
   ],
-  "people": ["Magnus Hirschfeld"],
-  "identities": ["asexual"],
-  "decades": [1920],
+  "people": [
+    "Magnus Hirschfeld"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    1920
+  ],
   "aliases": [],
   "id": "ih6XiwIOYsv0",
   "from_year": 1921

--- a/submissions/hirschfeld-sexualpathologie.json
+++ b/submissions/hirschfeld-sexualpathologie.json
@@ -43,21 +43,11 @@
     {
       "name": "Partial English Translation",
       "url": "https://www.asexuality.org/en/topic/98639-indirect-mentions-of-asexuality-in-magnus-hirschfelds-books/"
-    },
-    {
-      "name": "Partial English Translation",
-      "url": "https://web.archive.org/web/20220120124921/https://www.asexuality.org/en/topic/98639-indirect-mentions-of-asexuality-in-magnus-hirschfelds-books/"
     }
   ],
-  "people": [
-    "Magnus Hirschfeld"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    1920
-  ],
+  "people": ["Magnus Hirschfeld"],
+  "identities": ["asexual"],
+  "decades": [1920],
   "aliases": [],
   "id": "ih6XiwIOYsv0",
   "from_year": 1921

--- a/submissions/introduction-of-asexual-flag.json
+++ b/submissions/introduction-of-asexual-flag.json
@@ -10,61 +10,29 @@
       "url": "https://www.asexuality.org/en/topic/51646-asexual-flag-thread/"
     },
     {
-      "name": "Asexual Flag Thread",
-      "url": "https://web.archive.org/web/20220328213540/https://www.asexuality.org/en/topic/51646-asexual-flag-thread/"
-    },
-    {
       "name": "Discussion 2.0: Asexual Flag",
       "url": "https://www.asexuality.org/en/topic/51825-discussion-20-asexual-flag/"
-    },
-    {
-      "name": "Discussion 2.0: Asexual Flag",
-      "url": "https://web.archive.org/web/20220328213548/https://www.asexuality.org/en/topic/51825-discussion-20-asexual-flag/"
     },
     {
       "name": "Asexual Flag Voting (First Round)",
       "url": "https://www.asexuality.org/en/topic/51751-asexual-flag-voting-first-round/"
     },
     {
-      "name": "Asexual Flag Voting (First Round)",
-      "url": "https://web.archive.org/web/20220328213451/https://www.asexuality.org/en/topic/51751-asexual-flag-voting-first-round/"
-    },
-    {
       "name": "Asexual Flag Voting (Second Round)",
       "url": "https://www.asexuality.org/en/topic/52813-asexual-flag-voting-second-round/"
-    },
-    {
-      "name": "Asexual Flag Voting (Second Round)",
-      "url": "https://web.archive.org/web/20220510132816/https://www.asexuality.org/en/topic/52813-asexual-flag-voting-second-round/"
     },
     {
       "name": "Asexual Flag - Round Three",
       "url": "https://www.asexuality.org/en/topic/53110-asexual-flag-round-three/"
     },
     {
-      "name": "Asexual Flag - Round Three",
-      "url": "https://web.archive.org/web/20220328213521/https://www.asexuality.org/en/topic/53110-asexual-flag-round-three/"
-    },
-    {
       "name": "Asexual Flag: And the winner is.....",
       "url": "https://www.asexuality.org/en/topic/53435-asexual-flag-and-the-winner-is/"
-    },
-    {
-      "name": "Asexual Flag: And the winner is.....",
-      "url": "https://web.archive.org/web/20220422192628/https://www.asexuality.org/en/topic/53435-asexual-flag-and-the-winner-is/"
     }
   ],
-  "people": [
-    "bristrek",
-    "standup"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    2000,
-    2010
-  ],
+  "people": ["bristrek", "standup"],
+  "identities": ["asexual"],
+  "decades": [2000, 2010],
   "aliases": [],
   "id": "0XPaZ7HyJVfM",
   "from_year": 2009,

--- a/submissions/introduction-of-asexual-flag.json
+++ b/submissions/introduction-of-asexual-flag.json
@@ -30,9 +30,17 @@
       "url": "https://www.asexuality.org/en/topic/53435-asexual-flag-and-the-winner-is/"
     }
   ],
-  "people": ["bristrek", "standup"],
-  "identities": ["asexual"],
-  "decades": [2000, 2010],
+  "people": [
+    "bristrek",
+    "standup"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    2000,
+    2010
+  ],
   "aliases": [],
   "id": "0XPaZ7HyJVfM",
   "from_year": 2009,

--- a/submissions/nederland-asexuals-have-problems-too.json
+++ b/submissions/nederland-asexuals-have-problems-too.json
@@ -18,21 +18,11 @@
     {
       "name": "Article",
       "url": "https://www.villagevoice.com/asexuals-have-problems-too/"
-    },
-    {
-      "name": "Article",
-      "url": "https://web.archive.org/web/20230912223834/https://www.villagevoice.com/asexuals-have-problems-too/"
     }
   ],
-  "people": [
-    "Harold Nederland"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    1970
-  ],
+  "people": ["Harold Nederland"],
+  "identities": ["asexual"],
+  "decades": [1970],
   "aliases": [],
   "id": "JqyAVmG7TFY7",
   "from_year": 1971

--- a/submissions/nederland-asexuals-have-problems-too.json
+++ b/submissions/nederland-asexuals-have-problems-too.json
@@ -20,9 +20,15 @@
       "url": "https://www.villagevoice.com/asexuals-have-problems-too/"
     }
   ],
-  "people": ["Harold Nederland"],
-  "identities": ["asexual"],
-  "decades": [1970],
+  "people": [
+    "Harold Nederland"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    1970
+  ],
   "aliases": [],
   "id": "JqyAVmG7TFY7",
   "from_year": 1971

--- a/submissions/nordgren-manifesto-relationship-anarchy.json
+++ b/submissions/nordgren-manifesto-relationship-anarchy.json
@@ -35,9 +35,13 @@
       "url": "https://log.andie.se/post/26652940513/the-short-instructional-manifesto-for-relationship"
     }
   ],
-  "people": ["Andie Nordgren"],
+  "people": [
+    "Andie Nordgren"
+  ],
   "identities": [],
-  "decades": [2000],
+  "decades": [
+    2000
+  ],
   "aliases": [],
   "id": "PGQPnYtDNspJ",
   "from_year": 2006

--- a/submissions/nordgren-manifesto-relationship-anarchy.json
+++ b/submissions/nordgren-manifesto-relationship-anarchy.json
@@ -31,25 +31,13 @@
       "url": "https://theanarchistlibrary.org/library/andie-nordgren-the-short-instructional-manifesto-for-relationship-anarchy"
     },
     {
-      "name": "The Anarchist Library",
-      "url": "https://web.archive.org/web/20220415082857/https://theanarchistlibrary.org/library/andie-nordgren-the-short-instructional-manifesto-for-relationship-anarchy"
-    },
-    {
       "name": "Andie's Log",
       "url": "https://log.andie.se/post/26652940513/the-short-instructional-manifesto-for-relationship"
-    },
-    {
-      "name": "Andie's Log",
-      "url": "https://web.archive.org/web/20220208140553/https://log.andie.se/post/26652940513/the-short-instructional-manifesto-for-relationship"
     }
   ],
-  "people": [
-    "Andie Nordgren"
-  ],
+  "people": ["Andie Nordgren"],
   "identities": [],
-  "decades": [
-    2000
-  ],
+  "decades": [2000],
   "aliases": [],
   "id": "PGQPnYtDNspJ",
   "from_year": 2006

--- a/submissions/radford-no-sex-please.json
+++ b/submissions/radford-no-sex-please.json
@@ -9,21 +9,11 @@
     {
       "name": "Article",
       "url": "https://www.theguardian.com/science/2004/oct/14/science.research1"
-    },
-    {
-      "name": "Article",
-      "url": "https://web.archive.org/web/20210731082634/https://www.theguardian.com/science/2004/oct/14/science.research1"
     }
   ],
-  "people": [
-    "Tim Radford"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    2000
-  ],
+  "people": ["Tim Radford"],
+  "identities": ["asexual"],
+  "decades": [2000],
   "aliases": [],
   "id": "nXn2LQq3brJj",
   "from_year": 2004

--- a/submissions/radford-no-sex-please.json
+++ b/submissions/radford-no-sex-please.json
@@ -11,9 +11,15 @@
       "url": "https://www.theguardian.com/science/2004/oct/14/science.research1"
     }
   ],
-  "people": ["Tim Radford"],
-  "identities": ["asexual"],
-  "decades": [2000],
+  "people": [
+    "Tim Radford"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    2000
+  ],
   "aliases": [],
   "id": "nXn2LQq3brJj",
   "from_year": 2004

--- a/submissions/titman-asexuality-before-cake.json
+++ b/submissions/titman-asexuality-before-cake.json
@@ -9,21 +9,11 @@
     {
       "name": "Blog Post",
       "url": "https://graphicexplanations.info/2017/10/29/asexuality-bc-before-cake/"
-    },
-    {
-      "name": "Blog Post",
-      "url": "https://web.archive.org/web/20220408062115/https://graphicexplanations.info/2017/10/29/asexuality-bc-before-cake/"
     }
   ],
-  "people": [
-    "Nat Titman"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    2010
-  ],
+  "people": ["Nat Titman"],
+  "identities": ["asexual"],
+  "decades": [2010],
   "aliases": [],
   "id": "vvnGEyez3JMj",
   "from_year": 2017

--- a/submissions/titman-asexuality-before-cake.json
+++ b/submissions/titman-asexuality-before-cake.json
@@ -11,9 +11,15 @@
       "url": "https://graphicexplanations.info/2017/10/29/asexuality-bc-before-cake/"
     }
   ],
-  "people": ["Nat Titman"],
-  "identities": ["asexual"],
-  "decades": [2010],
+  "people": [
+    "Nat Titman"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    2010
+  ],
   "aliases": [],
   "id": "vvnGEyez3JMj",
   "from_year": 2017

--- a/submissions/westphal-glad-to-be-asexual.json
+++ b/submissions/westphal-glad-to-be-asexual.json
@@ -11,9 +11,16 @@
       "url": "https://www.newscientist.com/article/dn6533-feature-glad-to-be-asexual/"
     }
   ],
-  "people": ["Sylvia Pagán Westphal", "David Jay"],
-  "identities": ["asexual"],
-  "decades": [2000],
+  "people": [
+    "Sylvia Pagán Westphal",
+    "David Jay"
+  ],
+  "identities": [
+    "asexual"
+  ],
+  "decades": [
+    2000
+  ],
   "aliases": [],
   "id": "tqfVD2Tc8nVW",
   "from_year": 2004

--- a/submissions/westphal-glad-to-be-asexual.json
+++ b/submissions/westphal-glad-to-be-asexual.json
@@ -9,22 +9,11 @@
     {
       "name": "Article",
       "url": "https://www.newscientist.com/article/dn6533-feature-glad-to-be-asexual/"
-    },
-    {
-      "name": "Article",
-      "url": "https://web.archive.org/web/20211029020518/https://www.newscientist.com/article/dn6533-feature-glad-to-be-asexual/"
     }
   ],
-  "people": [
-    "Sylvia Pagán Westphal",
-    "David Jay"
-  ],
-  "identities": [
-    "asexual"
-  ],
-  "decades": [
-    2000
-  ],
+  "people": ["Sylvia Pagán Westphal", "David Jay"],
+  "identities": ["asexual"],
+  "decades": [2000],
   "aliases": [],
   "id": "tqfVD2Tc8nVW",
   "from_year": 2004


### PR DESCRIPTION
We probably don't need to be adding a Wayback link for every regular link. If the site is ever taken down, users can just go to the Wayback Machine themselves, or we can edit the artifact to add a Wayback link.

This commit updates the guidance to only instruct users to use Wayback links when the site is no longer available on the web or has changed substantially.