### PR TITLE
Update identity labels in artifacts

### DIFF
--- a/submissions/gay-liberator-transsexual-liberation.json
+++ b/submissions/gay-liberator-transsexual-liberation.json
@@ -52,13 +52,8 @@
     }
   ],
   "people": [],
-  "identities": [
-    "transgender",
-    "asexual"
-  ],
-  "decades": [
-    1970
-  ],
+  "identities": ["transsexual", "transvestite", "asexual"],
+  "decades": [1970],
   "aliases": [],
   "id": "FJXeTAaaQbjY",
   "from_year": 1971

--- a/submissions/gay-liberator-transsexual-liberation.json
+++ b/submissions/gay-liberator-transsexual-liberation.json
@@ -52,8 +52,14 @@
     }
   ],
   "people": [],
-  "identities": ["transsexual", "transvestite", "asexual"],
-  "decades": [1970],
+  "identities": [
+    "transsexual",
+    "transvestite",
+    "asexual"
+  ],
+  "decades": [
+    1970
+  ],
   "aliases": [],
   "id": "FJXeTAaaQbjY",
   "from_year": 1971

--- a/submissions/transvestia-vol-9-no-52.json
+++ b/submissions/transvestia-vol-9-no-52.json
@@ -33,9 +33,15 @@
     }
   ],
   "people": [],
-  "identities": ["asexual", "transvestite", "transsexual"],
+  "identities": [
+    "asexual",
+    "transvestite",
+    "transsexual"
+  ],
   "from_year": 1968,
-  "decades": [1960],
+  "decades": [
+    1960
+  ],
   "aliases": [],
   "id": "Mk81Z9GfUdpb"
 }

--- a/submissions/transvestia-vol-9-no-52.json
+++ b/submissions/transvestia-vol-9-no-52.json
@@ -33,14 +33,9 @@
     }
   ],
   "people": [],
-  "identities": [
-    "asexual",
-    "transgender"
-  ],
+  "identities": ["asexual", "transvestite", "transsexual"],
   "from_year": 1968,
-  "decades": [
-    1960
-  ],
+  "decades": [1960],
   "aliases": [],
   "id": "Mk81Z9GfUdpb"
 }

--- a/submissions/tv-guise-vol-1-iss-9.json
+++ b/submissions/tv-guise-vol-1-iss-9.json
@@ -31,10 +31,18 @@
       "url": "https://www.digitaltransgenderarchive.net/files/1544bp20p"
     }
   ],
-  "people": ["Billie Jean Jones"],
-  "identities": ["asexual", "transgender", "transsexual"],
+  "people": [
+    "Billie Jean Jones"
+  ],
+  "identities": [
+    "asexual",
+    "transgender",
+    "transsexual"
+  ],
   "from_year": 1992,
-  "decades": [1990],
+  "decades": [
+    1990
+  ],
   "aliases": [],
   "id": "ehvbKRQ2Thgc"
 }

--- a/submissions/tv-guise-vol-1-iss-9.json
+++ b/submissions/tv-guise-vol-1-iss-9.json
@@ -31,17 +31,10 @@
       "url": "https://www.digitaltransgenderarchive.net/files/1544bp20p"
     }
   ],
-  "people": [
-    "Billie Jean Jones"
-  ],
-  "identities": [
-    "asexual",
-    "transgender"
-  ],
+  "people": ["Billie Jean Jones"],
+  "identities": ["asexual", "transgender", "transsexual"],
   "from_year": 1992,
-  "decades": [
-    1990
-  ],
+  "decades": [1990],
   "aliases": [],
   "id": "ehvbKRQ2Thgc"
 }


### PR DESCRIPTION
These identity labels were updated to reflect the actual language used in the texts, to avoid retroactively applying contemporary identity labels to people who might not have otherwise used them.